### PR TITLE
Export metadata files along with png/gif, in order to retain eyes/mouth metadata.

### DIFF
--- a/src/com/sfc/sf2/portrait/PortraitManager.java
+++ b/src/com/sfc/sf2/portrait/PortraitManager.java
@@ -11,6 +11,7 @@ import com.sfc.sf2.portrait.io.DisassemblyManager;
 import com.sfc.sf2.portrait.io.PngManager;
 import com.sfc.sf2.portrait.io.GifManager;
 import com.sfc.sf2.palette.PaletteManager;
+import com.sfc.sf2.portrait.io.MetaManager;
 
 /**
  *
@@ -52,32 +53,44 @@ public class PortraitManager {
     }
     
     
-    public void importPng(String filepath){
+    public void importPng(String filepath, String metadataPath){
         System.out.println("com.sfc.sf2.portrait.PortraitManager.importPng() - Importing PNG ...");
         portrait.setTiles(PngManager.importPng(filepath).getTiles());
+        MetaManager.importMetadata(portrait, getMetadataFullPath(filepath, metadataPath));
         this.tiles = portrait.getTiles();
         graphicsManager.setTiles(portrait.getTiles());
         System.out.println("com.sfc.sf2.portrait.PortraitManager.importPng() - PNG imported.");
     }
     
-    public void exportPng(String filepath){
+    public void exportPng(String filepath, String metadataPath){
         System.out.println("com.sfc.sf2.portrait.PortraitManager.exportPng() - Exporting PNG ...");
         PngManager.exportPng(portrait, filepath);
+        MetaManager.exportMetadata(portrait, getMetadataFullPath(filepath, metadataPath));
         System.out.println("com.sfc.sf2.portrait.PortraitManager.exportPng() - PNG exported.");       
     }
     
-    public void importGif(String filepath){
+    public void importGif(String filepath, String metadataPath){
         System.out.println("com.sfc.sf2.portrait.PortraitManager.importGif() - Importing GIF ...");
         portrait.setTiles(GifManager.importGif(filepath).getTiles());
+        MetaManager.importMetadata(portrait, getMetadataFullPath(filepath, metadataPath));
         this.tiles = portrait.getTiles();
         graphicsManager.setTiles(portrait.getTiles());
         System.out.println("com.sfc.sf2.portrait.PortraitManager.importGif() - GIF imported.");
     }
     
-    public void exportGif(String filepath){
+    public void exportGif(String filepath, String metadataPath){
         System.out.println("com.sfc.sf2.portrait.PortraitManager.exportGif() - Exporting GIF ...");
         GifManager.exportGif(portrait, filepath);
+        MetaManager.exportMetadata(portrait, getMetadataFullPath(filepath, metadataPath));
         System.out.println("com.sfc.sf2.portrait.PortraitManager.exportGif() - GIF exported.");       
+    }
+    
+    private String getMetadataFullPath(String filepath, String metadataPath) {
+        if (metadataPath.equals(".meta")) {
+            return filepath.substring(0, filepath.lastIndexOf('.'))+metadataPath;
+        } else {
+            return metadataPath;
+        }
     }
 
     public Portrait getPortrait() {

--- a/src/com/sfc/sf2/portrait/gui/MainEditor.form
+++ b/src/com/sfc/sf2/portrait/gui/MainEditor.form
@@ -572,9 +572,6 @@
                                       <Properties>
                                         <Property name="text" type="java.lang.String" value=".\u005cportrait00.bin" containsInvalidXMLChars="true"/>
                                       </Properties>
-                                      <Events>
-                                        <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="jTextField9ActionPerformed"/>
-                                      </Events>
                                     </Component>
                                     <Component class="javax.swing.JLabel" name="jLabel10">
                                       <Properties>
@@ -618,6 +615,13 @@
                                                       <EmptySpace max="-2" attributes="0"/>
                                                       <Component id="jButton12" min="-2" max="-2" attributes="0"/>
                                                   </Group>
+                                                  <Group type="102" alignment="1" attributes="0">
+                                                      <Component id="jLabel17" min="-2" max="-2" attributes="0"/>
+                                                      <EmptySpace max="-2" attributes="0"/>
+                                                      <Component id="jTextField14" pref="324" max="32767" attributes="0"/>
+                                                      <EmptySpace max="-2" attributes="0"/>
+                                                      <Component id="jButton21" min="-2" max="-2" attributes="0"/>
+                                                  </Group>
                                               </Group>
                                               <EmptySpace max="-2" attributes="0"/>
                                           </Group>
@@ -632,6 +636,12 @@
                                                   <Component id="jButton17" alignment="3" min="-2" max="-2" attributes="0"/>
                                               </Group>
                                               <EmptySpace max="-2" attributes="0"/>
+                                              <Group type="103" groupAlignment="3" attributes="0">
+                                                  <Component id="jTextField14" alignment="3" min="-2" max="-2" attributes="0"/>
+                                                  <Component id="jLabel17" alignment="3" min="-2" max="-2" attributes="0"/>
+                                                  <Component id="jButton21" alignment="3" min="-2" max="-2" attributes="0"/>
+                                              </Group>
+                                              <EmptySpace max="32767" attributes="0"/>
                                               <Group type="103" groupAlignment="0" attributes="0">
                                                   <Component id="jButton12" min="-2" max="-2" attributes="0"/>
                                                   <Component id="jLabel3" min="-2" max="-2" attributes="0"/>
@@ -651,9 +661,6 @@
                                       <Properties>
                                         <Property name="text" type="java.lang.String" value=".\u005cportrait00.png" containsInvalidXMLChars="true"/>
                                       </Properties>
-                                      <Events>
-                                        <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="jTextField11ActionPerformed"/>
-                                      </Events>
                                     </Component>
                                     <Component class="javax.swing.JButton" name="jButton17">
                                       <Properties>
@@ -675,6 +682,24 @@
                                       <Properties>
                                         <Property name="text" type="java.lang.String" value="&lt;html&gt;Select a PNG file.&lt;br&gt;Required PNG Format : 4BPP / 16 indexed colors.&lt;br/&gt;Transparency color at index 0.&lt;/html&gt;"/>
                                       </Properties>
+                                    </Component>
+                                    <Component class="javax.swing.JLabel" name="jLabel17">
+                                      <Properties>
+                                        <Property name="text" type="java.lang.String" value="Meta File :"/>
+                                      </Properties>
+                                    </Component>
+                                    <Component class="javax.swing.JTextField" name="jTextField14">
+                                      <Properties>
+                                        <Property name="text" type="java.lang.String" value=".meta"/>
+                                      </Properties>
+                                    </Component>
+                                    <Component class="javax.swing.JButton" name="jButton21">
+                                      <Properties>
+                                        <Property name="text" type="java.lang.String" value="File..."/>
+                                      </Properties>
+                                      <Events>
+                                        <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="jButton21ActionPerformed"/>
+                                      </Events>
                                     </Component>
                                   </SubComponents>
                                 </Container>
@@ -705,6 +730,13 @@
                                                       <EmptySpace max="-2" attributes="0"/>
                                                       <Component id="jButton14" min="-2" max="-2" attributes="0"/>
                                                   </Group>
+                                                  <Group type="102" alignment="1" attributes="0">
+                                                      <Component id="jLabel18" min="-2" max="-2" attributes="0"/>
+                                                      <EmptySpace max="-2" attributes="0"/>
+                                                      <Component id="jTextField17" pref="324" max="32767" attributes="0"/>
+                                                      <EmptySpace max="-2" attributes="0"/>
+                                                      <Component id="jButton22" min="-2" max="-2" attributes="0"/>
+                                                  </Group>
                                               </Group>
                                               <EmptySpace max="-2" attributes="0"/>
                                           </Group>
@@ -719,6 +751,12 @@
                                                   <Component id="jButton19" alignment="3" min="-2" max="-2" attributes="0"/>
                                               </Group>
                                               <EmptySpace max="-2" attributes="0"/>
+                                              <Group type="103" groupAlignment="3" attributes="0">
+                                                  <Component id="jTextField17" alignment="3" min="-2" max="-2" attributes="0"/>
+                                                  <Component id="jLabel18" alignment="3" min="-2" max="-2" attributes="0"/>
+                                                  <Component id="jButton22" alignment="3" min="-2" max="-2" attributes="0"/>
+                                              </Group>
+                                              <EmptySpace max="32767" attributes="0"/>
                                               <Group type="103" groupAlignment="0" attributes="0">
                                                   <Component id="jButton14" alignment="0" min="-2" max="-2" attributes="0"/>
                                                   <Component id="jLabel4" alignment="0" min="-2" max="-2" attributes="0"/>
@@ -738,9 +776,6 @@
                                       <Properties>
                                         <Property name="text" type="java.lang.String" value=".\u005cportrait00.gif" containsInvalidXMLChars="true"/>
                                       </Properties>
-                                      <Events>
-                                        <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="jTextField12ActionPerformed"/>
-                                      </Events>
                                     </Component>
                                     <Component class="javax.swing.JButton" name="jButton19">
                                       <Properties>
@@ -761,6 +796,24 @@
                                       </Properties>
                                       <Events>
                                         <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="jButton14ActionPerformed"/>
+                                      </Events>
+                                    </Component>
+                                    <Component class="javax.swing.JLabel" name="jLabel18">
+                                      <Properties>
+                                        <Property name="text" type="java.lang.String" value="Meta File :"/>
+                                      </Properties>
+                                    </Component>
+                                    <Component class="javax.swing.JTextField" name="jTextField17">
+                                      <Properties>
+                                        <Property name="text" type="java.lang.String" value=".meta"/>
+                                      </Properties>
+                                    </Component>
+                                    <Component class="javax.swing.JButton" name="jButton22">
+                                      <Properties>
+                                        <Property name="text" type="java.lang.String" value="File..."/>
+                                      </Properties>
+                                      <Events>
+                                        <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="jButton22ActionPerformed"/>
                                       </Events>
                                     </Component>
                                   </SubComponents>
@@ -875,9 +928,6 @@
                                       <Properties>
                                         <Property name="text" type="java.lang.String" value=".\u005cportrait00.bin" containsInvalidXMLChars="true"/>
                                       </Properties>
-                                      <Events>
-                                        <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="jTextField13ActionPerformed"/>
-                                      </Events>
                                     </Component>
                                     <Component class="javax.swing.JButton" name="jButton20">
                                       <Properties>
@@ -916,6 +966,13 @@
                                                       <EmptySpace max="-2" attributes="0"/>
                                                       <Component id="jButton13" min="-2" max="-2" attributes="0"/>
                                                   </Group>
+                                                  <Group type="102" alignment="1" attributes="0">
+                                                      <Component id="jLabel19" min="-2" max="-2" attributes="0"/>
+                                                      <EmptySpace max="-2" attributes="0"/>
+                                                      <Component id="jTextField18" pref="324" max="32767" attributes="0"/>
+                                                      <EmptySpace max="-2" attributes="0"/>
+                                                      <Component id="jButton23" min="-2" max="-2" attributes="0"/>
+                                                  </Group>
                                               </Group>
                                               <EmptySpace max="-2" attributes="0"/>
                                           </Group>
@@ -930,6 +987,12 @@
                                                   <Component id="jButton27" alignment="3" min="-2" max="-2" attributes="0"/>
                                               </Group>
                                               <EmptySpace max="-2" attributes="0"/>
+                                              <Group type="103" groupAlignment="3" attributes="0">
+                                                  <Component id="jTextField18" alignment="3" min="-2" max="-2" attributes="0"/>
+                                                  <Component id="jLabel19" alignment="3" min="-2" max="-2" attributes="0"/>
+                                                  <Component id="jButton23" alignment="3" min="-2" max="-2" attributes="0"/>
+                                              </Group>
+                                              <EmptySpace max="32767" attributes="0"/>
                                               <Group type="103" groupAlignment="0" attributes="0">
                                                   <Component id="jButton13" min="-2" max="-2" attributes="0"/>
                                                   <Component id="jLabel9" min="-2" max="-2" attributes="0"/>
@@ -949,9 +1012,6 @@
                                       <Properties>
                                         <Property name="text" type="java.lang.String" value=".\u005cportrait00.png" containsInvalidXMLChars="true"/>
                                       </Properties>
-                                      <Events>
-                                        <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="jTextField15ActionPerformed"/>
-                                      </Events>
                                     </Component>
                                     <Component class="javax.swing.JButton" name="jButton27">
                                       <Properties>
@@ -973,6 +1033,24 @@
                                       <Properties>
                                         <Property name="text" type="java.lang.String" value="&lt;html&gt;Creates a new file, or overwrites existing file.&lt;br&gt;Exported PNG Format : 4BPP / 16 indexed colors.&lt;br/&gt;Transparency color at index 0.&lt;/html&gt;"/>
                                       </Properties>
+                                    </Component>
+                                    <Component class="javax.swing.JLabel" name="jLabel19">
+                                      <Properties>
+                                        <Property name="text" type="java.lang.String" value="Meta File :"/>
+                                      </Properties>
+                                    </Component>
+                                    <Component class="javax.swing.JTextField" name="jTextField18">
+                                      <Properties>
+                                        <Property name="text" type="java.lang.String" value=".meta"/>
+                                      </Properties>
+                                    </Component>
+                                    <Component class="javax.swing.JButton" name="jButton23">
+                                      <Properties>
+                                        <Property name="text" type="java.lang.String" value="File..."/>
+                                      </Properties>
+                                      <Events>
+                                        <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="jButton23ActionPerformed"/>
+                                      </Events>
                                     </Component>
                                   </SubComponents>
                                 </Container>
@@ -1003,6 +1081,13 @@
                                                       <EmptySpace max="-2" attributes="0"/>
                                                       <Component id="jButton16" min="-2" max="-2" attributes="0"/>
                                                   </Group>
+                                                  <Group type="102" alignment="1" attributes="0">
+                                                      <Component id="jLabel20" min="-2" max="-2" attributes="0"/>
+                                                      <EmptySpace max="-2" attributes="0"/>
+                                                      <Component id="jTextField19" pref="324" max="32767" attributes="0"/>
+                                                      <EmptySpace max="-2" attributes="0"/>
+                                                      <Component id="jButton24" min="-2" max="-2" attributes="0"/>
+                                                  </Group>
                                               </Group>
                                               <EmptySpace max="-2" attributes="0"/>
                                           </Group>
@@ -1017,6 +1102,12 @@
                                                   <Component id="jButton28" alignment="3" min="-2" max="-2" attributes="0"/>
                                               </Group>
                                               <EmptySpace max="-2" attributes="0"/>
+                                              <Group type="103" groupAlignment="3" attributes="0">
+                                                  <Component id="jTextField19" alignment="3" min="-2" max="-2" attributes="0"/>
+                                                  <Component id="jLabel20" alignment="3" min="-2" max="-2" attributes="0"/>
+                                                  <Component id="jButton24" alignment="3" min="-2" max="-2" attributes="0"/>
+                                              </Group>
+                                              <EmptySpace max="32767" attributes="0"/>
                                               <Group type="103" groupAlignment="0" attributes="0">
                                                   <Component id="jButton16" alignment="0" min="-2" max="-2" attributes="0"/>
                                                   <Component id="jLabel13" alignment="0" min="-2" max="-2" attributes="0"/>
@@ -1036,9 +1127,6 @@
                                       <Properties>
                                         <Property name="text" type="java.lang.String" value=".\u005cportrait00.gif" containsInvalidXMLChars="true"/>
                                       </Properties>
-                                      <Events>
-                                        <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="jTextField16ActionPerformed"/>
-                                      </Events>
                                     </Component>
                                     <Component class="javax.swing.JButton" name="jButton28">
                                       <Properties>
@@ -1059,6 +1147,24 @@
                                       </Properties>
                                       <Events>
                                         <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="jButton16ActionPerformed"/>
+                                      </Events>
+                                    </Component>
+                                    <Component class="javax.swing.JLabel" name="jLabel20">
+                                      <Properties>
+                                        <Property name="text" type="java.lang.String" value="Meta File :"/>
+                                      </Properties>
+                                    </Component>
+                                    <Component class="javax.swing.JTextField" name="jTextField19">
+                                      <Properties>
+                                        <Property name="text" type="java.lang.String" value=".meta"/>
+                                      </Properties>
+                                    </Component>
+                                    <Component class="javax.swing.JButton" name="jButton24">
+                                      <Properties>
+                                        <Property name="text" type="java.lang.String" value="File..."/>
+                                      </Properties>
+                                      <Events>
+                                        <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="jButton24ActionPerformed"/>
                                       </Events>
                                     </Component>
                                   </SubComponents>

--- a/src/com/sfc/sf2/portrait/gui/MainEditor.java
+++ b/src/com/sfc/sf2/portrait/gui/MainEditor.java
@@ -114,12 +114,18 @@ public class MainEditor extends javax.swing.JFrame {
         jButton17 = new javax.swing.JButton();
         jButton12 = new javax.swing.JButton();
         jLabel3 = new javax.swing.JLabel();
+        jLabel17 = new javax.swing.JLabel();
+        jTextField14 = new javax.swing.JTextField();
+        jButton21 = new javax.swing.JButton();
         jPanel16 = new javax.swing.JPanel();
         jLabel12 = new javax.swing.JLabel();
         jTextField12 = new javax.swing.JTextField();
         jButton19 = new javax.swing.JButton();
         jLabel4 = new javax.swing.JLabel();
         jButton14 = new javax.swing.JButton();
+        jLabel18 = new javax.swing.JLabel();
+        jTextField17 = new javax.swing.JTextField();
+        jButton22 = new javax.swing.JButton();
         jPanel5 = new javax.swing.JPanel();
         jTabbedPane2 = new javax.swing.JTabbedPane();
         jPanel11 = new javax.swing.JPanel();
@@ -134,12 +140,18 @@ public class MainEditor extends javax.swing.JFrame {
         jButton27 = new javax.swing.JButton();
         jButton13 = new javax.swing.JButton();
         jLabel9 = new javax.swing.JLabel();
+        jLabel19 = new javax.swing.JLabel();
+        jTextField18 = new javax.swing.JTextField();
+        jButton23 = new javax.swing.JButton();
         jPanel17 = new javax.swing.JPanel();
         jLabel16 = new javax.swing.JLabel();
         jTextField16 = new javax.swing.JTextField();
         jButton28 = new javax.swing.JButton();
         jLabel13 = new javax.swing.JLabel();
         jButton16 = new javax.swing.JButton();
+        jLabel20 = new javax.swing.JLabel();
+        jTextField19 = new javax.swing.JTextField();
+        jButton24 = new javax.swing.JButton();
 
         jFileChooser2.setFileSelectionMode(javax.swing.JFileChooser.DIRECTORIES_ONLY);
 
@@ -407,11 +419,6 @@ public class MainEditor extends javax.swing.JFrame {
         jLabel2.setText("<html>Select a portrait file.<br/>Typical disassembly path : data/graphics/portraits/</html>");
 
         jTextField9.setText(".\\portrait00.bin");
-        jTextField9.addActionListener(new java.awt.event.ActionListener() {
-            public void actionPerformed(java.awt.event.ActionEvent evt) {
-                jTextField9ActionPerformed(evt);
-            }
-        });
 
         jLabel10.setText("File :");
 
@@ -460,11 +467,6 @@ public class MainEditor extends javax.swing.JFrame {
         jLabel11.setText("PNG File :");
 
         jTextField11.setText(".\\portrait00.png");
-        jTextField11.addActionListener(new java.awt.event.ActionListener() {
-            public void actionPerformed(java.awt.event.ActionEvent evt) {
-                jTextField11ActionPerformed(evt);
-            }
-        });
 
         jButton17.setText("File...");
         jButton17.addActionListener(new java.awt.event.ActionListener() {
@@ -482,6 +484,17 @@ public class MainEditor extends javax.swing.JFrame {
 
         jLabel3.setText("<html>Select a PNG file.<br>Required PNG Format : 4BPP / 16 indexed colors.<br/>Transparency color at index 0.</html>");
 
+        jLabel17.setText("Meta File :");
+
+        jTextField14.setText(".meta");
+
+        jButton21.setText("File...");
+        jButton21.addActionListener(new java.awt.event.ActionListener() {
+            public void actionPerformed(java.awt.event.ActionEvent evt) {
+                jButton21ActionPerformed(evt);
+            }
+        });
+
         javax.swing.GroupLayout jPanel9Layout = new javax.swing.GroupLayout(jPanel9);
         jPanel9.setLayout(jPanel9Layout);
         jPanel9Layout.setHorizontalGroup(
@@ -498,7 +511,13 @@ public class MainEditor extends javax.swing.JFrame {
                     .addGroup(jPanel9Layout.createSequentialGroup()
                         .addComponent(jLabel3)
                         .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
-                        .addComponent(jButton12)))
+                        .addComponent(jButton12))
+                    .addGroup(javax.swing.GroupLayout.Alignment.TRAILING, jPanel9Layout.createSequentialGroup()
+                        .addComponent(jLabel17)
+                        .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
+                        .addComponent(jTextField14, javax.swing.GroupLayout.DEFAULT_SIZE, 324, Short.MAX_VALUE)
+                        .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
+                        .addComponent(jButton21)))
                 .addContainerGap())
         );
         jPanel9Layout.setVerticalGroup(
@@ -509,6 +528,11 @@ public class MainEditor extends javax.swing.JFrame {
                     .addComponent(jLabel11)
                     .addComponent(jButton17))
                 .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
+                .addGroup(jPanel9Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.BASELINE)
+                    .addComponent(jTextField14, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
+                    .addComponent(jLabel17)
+                    .addComponent(jButton21))
+                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
                 .addGroup(jPanel9Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
                     .addComponent(jButton12)
                     .addComponent(jLabel3, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))
@@ -520,11 +544,6 @@ public class MainEditor extends javax.swing.JFrame {
         jLabel12.setText("GIF File :");
 
         jTextField12.setText(".\\portrait00.gif");
-        jTextField12.addActionListener(new java.awt.event.ActionListener() {
-            public void actionPerformed(java.awt.event.ActionEvent evt) {
-                jTextField12ActionPerformed(evt);
-            }
-        });
 
         jButton19.setText("File...");
         jButton19.addActionListener(new java.awt.event.ActionListener() {
@@ -539,6 +558,17 @@ public class MainEditor extends javax.swing.JFrame {
         jButton14.addActionListener(new java.awt.event.ActionListener() {
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 jButton14ActionPerformed(evt);
+            }
+        });
+
+        jLabel18.setText("Meta File :");
+
+        jTextField17.setText(".meta");
+
+        jButton22.setText("File...");
+        jButton22.addActionListener(new java.awt.event.ActionListener() {
+            public void actionPerformed(java.awt.event.ActionEvent evt) {
+                jButton22ActionPerformed(evt);
             }
         });
 
@@ -558,7 +588,13 @@ public class MainEditor extends javax.swing.JFrame {
                     .addGroup(javax.swing.GroupLayout.Alignment.TRAILING, jPanel16Layout.createSequentialGroup()
                         .addComponent(jLabel4)
                         .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
-                        .addComponent(jButton14)))
+                        .addComponent(jButton14))
+                    .addGroup(javax.swing.GroupLayout.Alignment.TRAILING, jPanel16Layout.createSequentialGroup()
+                        .addComponent(jLabel18)
+                        .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
+                        .addComponent(jTextField17, javax.swing.GroupLayout.DEFAULT_SIZE, 324, Short.MAX_VALUE)
+                        .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
+                        .addComponent(jButton22)))
                 .addContainerGap())
         );
         jPanel16Layout.setVerticalGroup(
@@ -569,6 +605,11 @@ public class MainEditor extends javax.swing.JFrame {
                     .addComponent(jLabel12)
                     .addComponent(jButton19))
                 .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
+                .addGroup(jPanel16Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.BASELINE)
+                    .addComponent(jTextField17, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
+                    .addComponent(jLabel18)
+                    .addComponent(jButton22))
+                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
                 .addGroup(jPanel16Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
                     .addComponent(jButton14)
                     .addComponent(jLabel4, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))
@@ -606,11 +647,6 @@ public class MainEditor extends javax.swing.JFrame {
         jLabel14.setText("File :");
 
         jTextField13.setText(".\\portrait00.bin");
-        jTextField13.addActionListener(new java.awt.event.ActionListener() {
-            public void actionPerformed(java.awt.event.ActionEvent evt) {
-                jTextField13ActionPerformed(evt);
-            }
-        });
 
         jButton20.setText("File...");
         jButton20.addActionListener(new java.awt.event.ActionListener() {
@@ -657,11 +693,6 @@ public class MainEditor extends javax.swing.JFrame {
         jLabel15.setText("PNG File :");
 
         jTextField15.setText(".\\portrait00.png");
-        jTextField15.addActionListener(new java.awt.event.ActionListener() {
-            public void actionPerformed(java.awt.event.ActionEvent evt) {
-                jTextField15ActionPerformed(evt);
-            }
-        });
 
         jButton27.setText("File...");
         jButton27.addActionListener(new java.awt.event.ActionListener() {
@@ -679,6 +710,17 @@ public class MainEditor extends javax.swing.JFrame {
 
         jLabel9.setText("<html>Creates a new file, or overwrites existing file.<br>Exported PNG Format : 4BPP / 16 indexed colors.<br/>Transparency color at index 0.</html>");
 
+        jLabel19.setText("Meta File :");
+
+        jTextField18.setText(".meta");
+
+        jButton23.setText("File...");
+        jButton23.addActionListener(new java.awt.event.ActionListener() {
+            public void actionPerformed(java.awt.event.ActionEvent evt) {
+                jButton23ActionPerformed(evt);
+            }
+        });
+
         javax.swing.GroupLayout jPanel14Layout = new javax.swing.GroupLayout(jPanel14);
         jPanel14.setLayout(jPanel14Layout);
         jPanel14Layout.setHorizontalGroup(
@@ -695,7 +737,13 @@ public class MainEditor extends javax.swing.JFrame {
                     .addGroup(javax.swing.GroupLayout.Alignment.TRAILING, jPanel14Layout.createSequentialGroup()
                         .addComponent(jLabel9)
                         .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
-                        .addComponent(jButton13)))
+                        .addComponent(jButton13))
+                    .addGroup(javax.swing.GroupLayout.Alignment.TRAILING, jPanel14Layout.createSequentialGroup()
+                        .addComponent(jLabel19)
+                        .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
+                        .addComponent(jTextField18, javax.swing.GroupLayout.DEFAULT_SIZE, 324, Short.MAX_VALUE)
+                        .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
+                        .addComponent(jButton23)))
                 .addContainerGap())
         );
         jPanel14Layout.setVerticalGroup(
@@ -706,6 +754,11 @@ public class MainEditor extends javax.swing.JFrame {
                     .addComponent(jLabel15)
                     .addComponent(jButton27))
                 .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
+                .addGroup(jPanel14Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.BASELINE)
+                    .addComponent(jTextField18, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
+                    .addComponent(jLabel19)
+                    .addComponent(jButton23))
+                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
                 .addGroup(jPanel14Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
                     .addComponent(jButton13)
                     .addComponent(jLabel9, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))
@@ -717,11 +770,6 @@ public class MainEditor extends javax.swing.JFrame {
         jLabel16.setText("GIF File :");
 
         jTextField16.setText(".\\portrait00.gif");
-        jTextField16.addActionListener(new java.awt.event.ActionListener() {
-            public void actionPerformed(java.awt.event.ActionEvent evt) {
-                jTextField16ActionPerformed(evt);
-            }
-        });
 
         jButton28.setText("File...");
         jButton28.addActionListener(new java.awt.event.ActionListener() {
@@ -736,6 +784,17 @@ public class MainEditor extends javax.swing.JFrame {
         jButton16.addActionListener(new java.awt.event.ActionListener() {
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 jButton16ActionPerformed(evt);
+            }
+        });
+
+        jLabel20.setText("Meta File :");
+
+        jTextField19.setText(".meta");
+
+        jButton24.setText("File...");
+        jButton24.addActionListener(new java.awt.event.ActionListener() {
+            public void actionPerformed(java.awt.event.ActionEvent evt) {
+                jButton24ActionPerformed(evt);
             }
         });
 
@@ -755,7 +814,13 @@ public class MainEditor extends javax.swing.JFrame {
                     .addGroup(javax.swing.GroupLayout.Alignment.TRAILING, jPanel17Layout.createSequentialGroup()
                         .addComponent(jLabel13)
                         .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
-                        .addComponent(jButton16)))
+                        .addComponent(jButton16))
+                    .addGroup(javax.swing.GroupLayout.Alignment.TRAILING, jPanel17Layout.createSequentialGroup()
+                        .addComponent(jLabel20)
+                        .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
+                        .addComponent(jTextField19, javax.swing.GroupLayout.DEFAULT_SIZE, 324, Short.MAX_VALUE)
+                        .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
+                        .addComponent(jButton24)))
                 .addContainerGap())
         );
         jPanel17Layout.setVerticalGroup(
@@ -766,6 +831,11 @@ public class MainEditor extends javax.swing.JFrame {
                     .addComponent(jLabel16)
                     .addComponent(jButton28))
                 .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
+                .addGroup(jPanel17Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.BASELINE)
+                    .addComponent(jTextField19, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
+                    .addComponent(jLabel20)
+                    .addComponent(jButton24))
+                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
                 .addGroup(jPanel17Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
                     .addComponent(jButton16)
                     .addComponent(jLabel13, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))
@@ -854,10 +924,6 @@ public class MainEditor extends javax.swing.JFrame {
         portraitManager.exportDisassembly(jTextField13.getText());
     }//GEN-LAST:event_jButton2ActionPerformed
 
-    private void jTextField15ActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_jTextField15ActionPerformed
-        // TODO add your handling code here:
-    }//GEN-LAST:event_jTextField15ActionPerformed
-
     private void jButton27ActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_jButton27ActionPerformed
         int returnVal = jFileChooser1.showOpenDialog(this);
         if (returnVal == JFileChooser.APPROVE_OPTION) {
@@ -867,13 +933,8 @@ public class MainEditor extends javax.swing.JFrame {
     }//GEN-LAST:event_jButton27ActionPerformed
 
     private void jButton13ActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_jButton13ActionPerformed
-        portraitManager.exportPng(jTextField15.getText());
-        setupPortraitLayout();
+        portraitManager.exportPng(jTextField15.getText(), jTextField18.getText());
     }//GEN-LAST:event_jButton13ActionPerformed
-
-    private void jTextField13ActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_jTextField13ActionPerformed
-        // TODO add your handling code here:
-    }//GEN-LAST:event_jTextField13ActionPerformed
 
     private void jButton20ActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_jButton20ActionPerformed
         int returnVal = jFileChooser2.showOpenDialog(this);
@@ -882,10 +943,6 @@ public class MainEditor extends javax.swing.JFrame {
             jTextField13.setText(file.getAbsolutePath());
         }
     }//GEN-LAST:event_jButton20ActionPerformed
-
-    private void jTextField16ActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_jTextField16ActionPerformed
-        // TODO add your handling code here:
-    }//GEN-LAST:event_jTextField16ActionPerformed
 
     private void jButton28ActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_jButton28ActionPerformed
         int returnVal = jFileChooser1.showOpenDialog(this);
@@ -896,7 +953,7 @@ public class MainEditor extends javax.swing.JFrame {
     }//GEN-LAST:event_jButton28ActionPerformed
 
     private void jButton16ActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_jButton16ActionPerformed
-        portraitManager.exportGif(jTextField16.getText());
+        portraitManager.exportGif(jTextField16.getText(), jTextField19.getText());
     }//GEN-LAST:event_jButton16ActionPerformed
 
     private void jButton1ActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_jButton1ActionPerformed
@@ -943,24 +1000,17 @@ public class MainEditor extends javax.swing.JFrame {
         }
     }//GEN-LAST:event_jCheckBox1ActionPerformed
 
-    private void jCheckBox3ActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_jCheckBox3ActionPerformed
+    private void jCheckBox3ActionPerformed(java.awt.event.ActionEvent evt) {                                           
         if (portraitLayout != null) {
             portraitLayout.setDrawGrid(jCheckBox3.isSelected());
             jPanel2.revalidate();
             jPanel2.repaint();  
         }
-    }//GEN-LAST:event_jCheckBox3ActionPerformed
-
-    private void jComboBox1ActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_jComboBox1ActionPerformed
-        if (portraitLayout != null) {
-            portraitLayout.setDisplaySize(jComboBox1.getSelectedIndex()+1);
-            jPanel2.revalidate();
-            jPanel2.repaint();  
-        }
-    }//GEN-LAST:event_jComboBox1ActionPerformed
+    }                                                                                 
 
     private void jButton14ActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_jButton14ActionPerformed
-        portraitManager.importGif(jTextField12.getText());
+        portraitManager.importGif(jTextField12.getText(), jTextField17.getText());
+        setupPortraitLayout();
     }//GEN-LAST:event_jButton14ActionPerformed
 
     private void jButton19ActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_jButton19ActionPerformed
@@ -971,12 +1021,8 @@ public class MainEditor extends javax.swing.JFrame {
         }
     }//GEN-LAST:event_jButton19ActionPerformed
 
-    private void jTextField12ActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_jTextField12ActionPerformed
-        // TODO add your handling code here:
-    }//GEN-LAST:event_jTextField12ActionPerformed
-
     private void jButton12ActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_jButton12ActionPerformed
-        portraitManager.importPng(jTextField11.getText());
+        portraitManager.importPng(jTextField11.getText(), jTextField14.getText());
         setupPortraitLayout();
     }//GEN-LAST:event_jButton12ActionPerformed
 
@@ -988,10 +1034,6 @@ public class MainEditor extends javax.swing.JFrame {
         }
     }//GEN-LAST:event_jButton17ActionPerformed
 
-    private void jTextField11ActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_jTextField11ActionPerformed
-        // TODO add your handling code here:
-    }//GEN-LAST:event_jTextField11ActionPerformed
-
     private void jButton15ActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_jButton15ActionPerformed
         int returnVal = jFileChooser1.showOpenDialog(this);
         if (returnVal == JFileChooser.APPROVE_OPTION) {
@@ -999,10 +1041,6 @@ public class MainEditor extends javax.swing.JFrame {
             jTextField9.setText(file.getAbsolutePath());
         }
     }//GEN-LAST:event_jButton15ActionPerformed
-
-    private void jTextField9ActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_jTextField9ActionPerformed
-        // TODO add your handling code here:
-    }//GEN-LAST:event_jTextField9ActionPerformed
 
     private void jButton18ActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_jButton18ActionPerformed
         portraitManager.importDisassembly(jTextField9.getText());
@@ -1059,6 +1097,46 @@ public class MainEditor extends javax.swing.JFrame {
         portraitLayout.setMouthAnimTable(mouthTable);
     }
     
+    private void jButton21ActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_jButton21ActionPerformed
+        int returnVal = jFileChooser1.showOpenDialog(this);
+        if (returnVal == JFileChooser.APPROVE_OPTION) {
+            File file = jFileChooser1.getSelectedFile();
+            jTextField14.setText(file.getAbsolutePath());
+        }
+    }//GEN-LAST:event_jButton21ActionPerformed
+
+    private void jButton22ActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_jButton22ActionPerformed
+        int returnVal = jFileChooser1.showOpenDialog(this);
+        if (returnVal == JFileChooser.APPROVE_OPTION) {
+            File file = jFileChooser1.getSelectedFile();
+            jTextField17.setText(file.getAbsolutePath());
+        }
+    }//GEN-LAST:event_jButton22ActionPerformed
+
+    private void jButton23ActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_jButton23ActionPerformed
+        int returnVal = jFileChooser1.showOpenDialog(this);
+        if (returnVal == JFileChooser.APPROVE_OPTION) {
+            File file = jFileChooser1.getSelectedFile();
+            jTextField18.setText(file.getAbsolutePath());
+        }
+    }//GEN-LAST:event_jButton23ActionPerformed
+
+    private void jButton24ActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_jButton24ActionPerformed
+        int returnVal = jFileChooser1.showOpenDialog(this);
+        if (returnVal == JFileChooser.APPROVE_OPTION) {
+            File file = jFileChooser1.getSelectedFile();
+            jTextField19.setText(file.getAbsolutePath());
+        }
+    }//GEN-LAST:event_jButton24ActionPerformed
+
+    private void jComboBox1ActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_jComboBox1ActionPerformed
+        if (portraitLayout != null) {
+            portraitLayout.setDisplaySize(jComboBox1.getSelectedIndex()+1);
+            jPanel2.revalidate();
+            jPanel2.repaint();  
+        }
+    }//GEN-LAST:event_jComboBox1ActionPerformed
+
     /**
      * @param args the command line arguments
      */
@@ -1112,6 +1190,10 @@ public class MainEditor extends javax.swing.JFrame {
     private javax.swing.JButton jButton19;
     private javax.swing.JButton jButton2;
     private javax.swing.JButton jButton20;
+    private javax.swing.JButton jButton21;
+    private javax.swing.JButton jButton22;
+    private javax.swing.JButton jButton23;
+    private javax.swing.JButton jButton24;
     private javax.swing.JButton jButton27;
     private javax.swing.JButton jButton28;
     private javax.swing.JButton jButton3;
@@ -1131,7 +1213,11 @@ public class MainEditor extends javax.swing.JFrame {
     private javax.swing.JLabel jLabel14;
     private javax.swing.JLabel jLabel15;
     private javax.swing.JLabel jLabel16;
+    private javax.swing.JLabel jLabel17;
+    private javax.swing.JLabel jLabel18;
+    private javax.swing.JLabel jLabel19;
     private javax.swing.JLabel jLabel2;
+    private javax.swing.JLabel jLabel20;
     private javax.swing.JLabel jLabel3;
     private javax.swing.JLabel jLabel4;
     private javax.swing.JLabel jLabel9;
@@ -1166,8 +1252,12 @@ public class MainEditor extends javax.swing.JFrame {
     private javax.swing.JTextField jTextField11;
     private javax.swing.JTextField jTextField12;
     private javax.swing.JTextField jTextField13;
+    private javax.swing.JTextField jTextField14;
     private javax.swing.JTextField jTextField15;
     private javax.swing.JTextField jTextField16;
+    private javax.swing.JTextField jTextField17;
+    private javax.swing.JTextField jTextField18;
+    private javax.swing.JTextField jTextField19;
     private javax.swing.JTextField jTextField9;
     // End of variables declaration//GEN-END:variables
 

--- a/src/com/sfc/sf2/portrait/io/MetaManager.java
+++ b/src/com/sfc/sf2/portrait/io/MetaManager.java
@@ -1,0 +1,104 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package com.sfc.sf2.portrait.io;
+
+import com.sfc.sf2.graphics.Tile;
+import com.sfc.sf2.portrait.Portrait;
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileReader;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ *
+ * @author TiMMy
+ */
+public class MetaManager {
+    
+    public static void importMetadata(Portrait portrait, String metadataPath){
+        try{
+            System.out.println("com.sfc.sf2.portrait.io.MetaManager.importMetadata() - Importing Meta file ...");
+            loadMetadataFile(portrait, metadataPath);
+            System.out.println("com.sfc.sf2.portrait.io.MetaManager.importMetadata() - Meta file imported.");
+        }catch(Exception e){
+             System.err.println("com.sfc.sf2.portrait.io.MetaManager.importMetadata() - Error while parsing metadata : "+e+". Will load without.");
+        }
+    }
+    
+    public static void loadMetadataFile(Portrait portrait, String filepath) throws IOException{
+        try {
+            System.out.println("com.sfc.sf2.portrait.io.MetaManager.loadMetadataFile() - Importing meta file ...");
+            File inputfile = new File(filepath);
+            System.out.println("File path : "+inputfile.getAbsolutePath());
+            BufferedReader reader = new BufferedReader(new FileReader(inputfile, Charset.defaultCharset()));
+            String data = reader.readLine();
+            int eyesCount = Integer.parseInt(data.split(":")[1].trim());
+            int[][] eyeTiles = new int[eyesCount][4];
+            for (int i = 0; i < eyesCount; i++) {
+                data = reader.readLine();
+                String[] eyeData = data.split(",");
+                for (int d = 0; d < eyeData.length; d++) {
+                    eyeTiles[i][d] = Integer.parseInt(eyeData[d].trim());
+                }
+            }
+            data = reader.readLine();
+            int mouthsCount = Integer.parseInt(data.split(" ")[1].trim());
+            int[][] mouthTiles = new int[mouthsCount][4];
+            for (int i = 0; i < mouthsCount; i++) {
+                data = reader.readLine();
+                String[] mouthsData = data.split(",");
+                for (int d = 0; d < mouthsData.length; d++) {
+                    mouthTiles[i][d] = Integer.parseInt(mouthsData[d].trim());
+                }
+            }
+            portrait.setEyeTiles(eyeTiles);
+            portrait.setMouthTiles(mouthTiles);
+            reader.close();
+            System.out.println("Meta file imported : " + inputfile.getAbsolutePath());
+        }catch(Exception e){
+             System.err.println("com.sfc.sf2.portrait.io.MetaManager.importMetaFile() - Error while parsing metadata : "+e);
+             throw e;
+        }              
+    }
+    
+    public static void exportMetadata(Portrait portrait, String metadataPath){
+        try {
+            System.out.println("com.sfc.sf2.portrait.io.MetaManager.exportMetadata() - Exporting Meta file ...");
+            writeMetadataFile(portrait.getEyeTiles(), portrait.getMouthTiles(), metadataPath);
+            System.out.println("com.sfc.sf2.portrait.io.MetaManager.exportMetadata() - Meta file exported.");
+        } catch (Exception ex) {
+            Logger.getLogger(PngManager.class.getName()).log(Level.SEVERE, null, ex);
+        }
+    }    
+    
+    public static void writeMetadataFile(int[][] eyeTiles, int[][] mouthTiles, String filepath){
+        try {
+            System.out.println("com.sfc.sf2.portrait.io.MetaManager.writeMetadataFile() - Exporting meta file ...");
+            StringBuilder sb = new StringBuilder();
+            sb.append(String.format("Eyes: %s\n", eyeTiles.length));
+            for (int i = 0; i < eyeTiles.length; i++) {
+                sb.append(String.format("%d, %d, %d, %d\n", eyeTiles[i][0], eyeTiles[i][1], eyeTiles[i][2], eyeTiles[i][3]));
+            }
+            sb.append(String.format("Mouths: %s\n", mouthTiles.length));
+            for (int i = 0; i < mouthTiles.length; i++) {
+                sb.append(String.format("%d, %d, %d, %d\n", mouthTiles[i][0], mouthTiles[i][1], mouthTiles[i][2], mouthTiles[i][3]));
+            }
+                        
+            File outputfile = new File(filepath);
+            System.out.println("File path : "+outputfile.getAbsolutePath());
+            FileWriter writer = new FileWriter(outputfile, Charset.defaultCharset(), false);
+            writer.write(sb.toString());
+            writer.close();
+            System.out.println("Meta file exported : " + outputfile.getAbsolutePath());
+        } catch (Exception ex) {
+            Logger.getLogger(MetaManager.class.getName()).log(Level.SEVERE, null, ex);
+        }       
+    }
+}


### PR DESCRIPTION
When exporting png/gif, the eye/mouth metadata is lost. When creating new portraits, I got sick of having to find a portrait with similar metadata and loading that before importing my png image.

This is a change that also exports a "portraitXX.meta" text file along with the portrait so that metadata can be retained.

There were 2 options for the metadata: Binary would be the most space efficient, but memory is not a big deal for project files so I opted for human-readable text (which can also be easily validated or edited by user.

Made as a PR in case there is no desire for these metadata files (I will use them anyway).

NOTE: png/gif files can still be loaded without a meta file (they just won't have any eye/mouth data).